### PR TITLE
Fix Firefox profile detection for XDG-compliant paths

### DIFF
--- a/1password-flatpak-browser-integration.sh
+++ b/1password-flatpak-browser-integration.sh
@@ -151,7 +151,18 @@ elif [[ "$BROWSER_TYPE" = "firefox" ]]; then
                 NATIVE_MESSAGING_HOSTS_DIR="$dir"/native-messaging-hosts
                 break
             fi
+
+            # Check one more level for XDG-compliant paths like config/mozilla/firefox
+            for subsubdir in "$subdir"/*; do
+                if is_firefox_dir "$subsubdir"; then
+                    # e.g., config/mozilla/firefox/profiles.ini -> config/mozilla/native-messaging-hosts
+                    NATIVE_MESSAGING_HOSTS_DIR="$subdir"/native-messaging-hosts
+                    break
+                fi
+            done
+            [[ -v NATIVE_MESSAGING_HOSTS_DIR ]] && break
         done
+        [[ -v NATIVE_MESSAGING_HOSTS_DIR ]] && break
     done
 fi
 


### PR DESCRIPTION
## Summary

Newer Firefox Flatpak versions store profiles in XDG-compliant paths like `config/mozilla/firefox/profiles.ini` instead of the legacy `.mozilla/firefox/profiles.ini` location.

The existing search only went 2 levels deep, missing the 3-level XDG structure. This PR adds a third level of iteration to handle both:

- **Legacy**: `.mozilla/firefox/profiles.ini` → `.mozilla/native-messaging-hosts`
- **XDG**: `config/mozilla/firefox/profiles.ini` → `config/mozilla/native-messaging-hosts`

## Test plan

- [ ] Test on system with legacy Firefox Flatpak structure (`.mozilla/firefox/`)
- [ ] Test on system with XDG-compliant Firefox Flatpak structure (`config/mozilla/firefox/`)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Firefox Native Messaging Hosts directory detection to support additional XDG-compliant directory layouts
  * Optimised search logic to identify required directories more efficiently

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->