### PR TITLE
Fix case where existing file ends with `#`

### DIFF
--- a/1password-flatpak-browser-integration.sh
+++ b/1password-flatpak-browser-integration.sh
@@ -247,7 +247,7 @@ if grep -q 'flatpak-session-helper' /etc/1password/custom_allowed_browsers; then
     echo -e "${INFO}Already added to allowed browsers${NC}"
 else
     echo -e "${INFO}Adding to allowed browsers${NC}"
-    echo -e 'flatpak-session-helper' | sudo tee -a /etc/1password/custom_allowed_browsers >/dev/null
+    printf '\nflatpak-session-helper\n' | sudo tee -a /etc/1password/custom_allowed_browsers >/dev/null
 fi
 
 # Done


### PR DESCRIPTION
Hello! First, thank you so much for this project. It has solved a long-standing issue.

After installation I was getting a message, "You're asked to re-enter your password because Firefox has an update available" which was not true. A bit of troubleshooting later I found the issue. My `/etc/1password/custom_allowed_browsers` looked like this:

```
# This file, when placed into /etc/1password/custom_allowed_browsers will allow for
# custom browsers to be defined that can work with 1Password for Linux's browser extension
# integration.
#
# 1Password for Linux custom browser allowlist
#
# To add a browser here, add the filename of the browser. Multiple can be seperated by a `\n`.
# Any lines starting with `#` will be ignored.
#
# Example:
#
# vivaldi-bin
# opera
#flatpak-session-helper
```

Removing the comment fixed my issue. 

The issue seems to stem from `echo -e 'flatpak-session-helper' | sudo tee -a /etc/1password/custom_allowed_browsers >/dev/null`. The fix just replaces the echo before the pipe with `printf '\nflatpak-session-helper\n'`, which adds a newline to avoid this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of browser integration configuration to ensure consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->